### PR TITLE
Adds install target which does not need make_bundle.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ BINDIR=/usr/local/bin
 all:
 	git submodule update --init
 	xbuild /property:Configuration=Release 
+
+makebundle: all
 	bash make_bundle
 
 clean:
@@ -16,11 +18,17 @@ clean:
 	rm -rf XR.Mono.Cover/obj
 	rm -rf XR.Mono.Cover/bin
 
-install:
+install_generic:
 	install -d $(INSTDIR) $(BINDIR)
-	install -m 755 covem $(BINDIR)
 	install covtool/bin/XR.Mono.Cover.dll $(INSTDIR)
 	install covtool/bin/cov-gtk.exe $(INSTDIR)
 	install covtool/bin/cov-html.exe $(INSTDIR)
 	install scripts/cov-gtk $(BINDIR)
 	install scripts/cov-html $(BINDIR)
+
+installbundle: install_generic
+	install -m 755 covem $(BINDIR)
+
+install: install_generic
+	install covtool/bin/covem.exe $(INSTDIR)
+	install scripts/covem $(BINDIR)

--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ If you wish to make the bundled binary (not necessary but easier to deploy) do:
 
 Which should give you the 'covem' program (on linux anyway)
 
+Installing
+-----------
+You can use the included Makefile to install baboon under Linux. 
+
+Use `make install` to install without using make_bundle (see above).
+Use `make installbundle` for installing the bundled version.
+
 Running
 --------
 

--- a/scripts/covem
+++ b/scripts/covem
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec mono /usr/local/lib/baboon/covem.exe "$@"


### PR DESCRIPTION
Hi,

as already discussed I changed the makefile to allow installation without make_bundle.

As make_bundle is picky and does not work everywhere I made the 'non bundled' install target the default and moved the bundled version to a target called installbundle. I hope this is ok for you? My idea was that that "make && make install" should now work on most installations without problems.

Greetings,

Fred
