### PR TITLE
Adaptet SPEC and Make-file to allow build under Fedora

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ INSTDIR=/usr/local/lib/baboon
 BINDIR=/usr/local/bin
 
 all:
-	git submodule update --init
 	xbuild /property:Configuration=Release 
 
 makebundle: all

--- a/mono-cover.spec
+++ b/mono-cover.spec
@@ -27,7 +27,7 @@ XR.Mono.Cover is a code coverage tool for mono/.NET
 make
 
 %install
-%makeinstall
+make DESTDIR=%{?buildroot:%{buildroot}} install
 
 %post 
 %postun


### PR DESCRIPTION
2nd try after https://github.com/inorton/XR.Baboon/pull/4
This time, the RPM should build under Fedora as well
