### PR TITLE
ArgumentException: Unable to sort

### DIFF
--- a/XR.Mono.Cover/CoverHost.cs
+++ b/XR.Mono.Cover/CoverHost.cs
@@ -391,7 +391,7 @@ namespace XR.Mono.Cover
             using (var f = new StreamWriter( filename )) {
                 var rv = records.Values.ToArray ();
                 Array.Sort (rv, (CodeRecord x, CodeRecord y) => {
-                    var xa = string.Format (x.ClassName + "\t:" + x.Name);
+                    var xa = string.Format (x.ClassName + ":" + x.Name);
                     var ya = string.Format (y.ClassName + ":" + y.Name);
 
                     return xa.CompareTo (ya);


### PR DESCRIPTION
We're getting an ArgumentException after collection NUnit coverage with XR.Baboon. Underlying problem is that the comparison of code records is not stable wrt changing the arguments. We fixed this by making the format string the same for both records.

```
Unhandled Exception:
System.ArgumentException: Unable to sort because the IComparer.Compare() method returns inconsistent results. Either a value does not compare equal to itself, or one value repeatedly compared to another value yields different results. IComparer: 'System.Comparison`1[XR.Mono.Cover.CodeRecord]'.
  at System.Collections.Generic.IntrospectiveSortUtilities.ThrowOrIgnoreBadComparer (System.Object comparer) [0x0000b] in <62f5937022004555807e6c57c33f6684>:0 
  at System.Collections.Generic.ArraySortHelper`1[T].Sort (T[] keys, System.Int32 index, System.Int32 length, System.Comparison`1[T] comparer) [0x0000c] in <62f5937022004555807e6c57c33f6684>:0 
  at System.Array.Sort[T] (T[] array, System.Comparison`1[T] comparison) [0x0001c] in <62f5937022004555807e6c57c33f6684>:0 
  at XR.Mono.Cover.CoverHost.Report (System.String filename) [0x0001d] in <49e5c73ffb9748b8b9592af9851a2f9b>:0 
  at Covtool.MainClass.Main (System.String[] vargs) [0x0017b] in <53a082663f0444d3bf9cea12675c4018>:0
```