### PR TITLE
Wait until VM process has exited (ensures correct return type)

### DIFF
--- a/XR.Mono.Cover/CoverHost.cs
+++ b/XR.Mono.Cover/CoverHost.cs
@@ -327,9 +327,11 @@ namespace XR.Mono.Cover
                     f.Write (ex.ToString ());
                 }
             } finally {
-
-                if ( !VirtualMachine.Process.HasExited )
-                    VirtualMachine.Process.Kill();
+                if ( !VirtualMachine.Process.HasExited && !VirtualMachine.Process.WaitForExit (10000) )
+                {
+                    Log ("vm still running, kill now");
+					VirtualMachine.Process.Kill();
+                }
 
                 Log("saving data");
 


### PR DESCRIPTION
If running NUnit with Baboon we're getting a return code of `127` when the tests succeed and `1` if they fail. I've debugged the issue and it looks like it also manifests for regular programs (at least with a mono 4 install).

Reason is that an `VMDisconnectedException` is thrown and the VM Process is still running. I've guarded the killing of the VM process by a 10sec wait for exit. We could also wait indefinitely here, but I guess 10sec are OK here. The VM actually exists within a few ms. 