### PR TITLE
Option to improve performance by disabling hit counting

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ or exe) atthe start of the line. Eg,
 
 And baboon will start the program and start recording coverage data.
 
+If you are only interested in line coverage without hit counts you can add the following line to the
+config file. This will increase performance significantly.
+
+`$HitCount=false`
+
 Results
 ========
 

--- a/XR.Mono.Cover/CoverHost.cs
+++ b/XR.Mono.Cover/CoverHost.cs
@@ -243,7 +243,7 @@ namespace XR.Mono.Cover
                         }
 
                         if (!HitCount) {
-							bpe.Request.Disable ();
+                            bpe.Request.Disable ();
                         }
                     }
 

--- a/XR.Mono.Cover/CoverHost.cs
+++ b/XR.Mono.Cover/CoverHost.cs
@@ -31,6 +31,8 @@ namespace XR.Mono.Cover
 
         public CodeRecordData DataStore { get; set; }
 
+        public bool HitCount { get; set; } = true;
+
 
         long logcount = 0;
 
@@ -238,6 +240,10 @@ namespace XR.Mono.Cover
                     
                         if ( bp.Location.LineNumber == bp.Record.GetFirstLine() ) {
                             rec.CallCount++;
+                        }
+
+                        if (!HitCount) {
+							bpe.Request.Disable ();
                         }
                     }
 

--- a/covtool/Program.cs
+++ b/covtool/Program.cs
@@ -103,14 +103,21 @@ of a type name like so:
                 cfgfile = env;
             }
 
+            bool hitCount = true;
             if ( File.Exists( cfgfile ) ) {
                 using ( var f = File.OpenText( cfgfile ) ) {
                     string l = null;
                     do {
                         l = f.ReadLine();
-                        if ( !string.IsNullOrWhiteSpace( l ) ) {
-                            patterns.Add(l);
+                        if ( string.IsNullOrWhiteSpace( l ) ) {
+                            continue;
                         }
+                        if (l.StartsWith ( "!HitCount=" ) ) {
+                            l = l.Substring("!HitCount=".Length);
+                            bool.TryParse (l, out hitCount);
+                            continue;
+                        }
+                        patterns.Add (l);
                     } while ( l != null );
                 }
             }
@@ -123,7 +130,8 @@ of a type name like so:
             debugee = covertool.VirtualMachine.Process;
             ThreadPool.QueueUserWorkItem( (x) => SignalHandler(), null );
             ThreadPool.QueueUserWorkItem( (x) => PumpStdin(x), null );
-			covertool.Cover (patterns.ToArray ());
+            covertool.HitCount = hitCount;
+            covertool.Cover (patterns.ToArray ());
             covertool.Report ( cfgfile + ".covreport" );
 
             return covertool.VirtualMachine.Process.ExitCode;

--- a/covtool/Program.cs
+++ b/covtool/Program.cs
@@ -41,6 +41,11 @@ of a type name like so:
 ^MyProject.Program
 ^XR.HttpFileStream
 
+Generating simple line coverage information instead of hit counting
+can be enabled in the configuration file like this:
+
+$HitCount=false
+
 
 ");
             Console.WriteLine();
@@ -112,8 +117,8 @@ of a type name like so:
                         if ( string.IsNullOrWhiteSpace( l ) ) {
                             continue;
                         }
-                        if (l.StartsWith ( "!HitCount=" ) ) {
-                            l = l.Substring("!HitCount=".Length);
+                        if (l.StartsWith ( "$HitCount=" ) ) {
+                            l = l.Substring("$HitCount=".Length);
                             bool.TryParse (l, out hitCount);
                             continue;
                         }


### PR DESCRIPTION
Running NUnit with XR.Baboon to collect coverage information hampered our test execution significantly:

Without Baboon the suite took less then a second to execute. With Baboon we were up to 8 Minutes.

Reason is hit-counting of already covered lines which causes several context switches (especially if tests include multi-threading / async-await). This PR introduces a config option (`$HitCount=false`) in the settings file that  optionally turns off hit-counting by disabling a breakpoint after pass-through. For our scenario this brought test times back to a few seconds.

