### PR TITLE
Attach to an existent process

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,16 @@ baboon can be attached to an existent process as Mono Soft-Mode Debugger. Eg,
 
 where `127.0.0.1` is the address and `19000` is the port number.
 
+If the process has a waiting thread, the thread may invoke a method when baboon
+is ready by adding the following lines to the config file:
+
+```
+$InvokeMethod=Namespace.TypeName.MethodName
+$InvokeThread=ThreadName
+```
+
+The method may trigger an execution of the code you are interested in.
+
 Results
 ========
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,15 @@ significantly.
 
 `$HitCount=false`
 
+Attaching to an existent process
+=================================
+
+baboon can be attached to an existent process as Mono Soft-Mode Debugger. Eg,
+
+`$ /home/inb/tmp/covem -a myserver.exe 127.0.0.1 19000`
+
+where `127.0.0.1` is the address and `19000` is the port number.
+
 Results
 ========
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ significantly.
 
 `$HitCount=false`
 
+The covering process may be interrupted by sending baboon _SIGINT_. The results
+will still be saved.
+
 Attaching to an existent process
 =================================
 

--- a/UnitTests/Test.cs
+++ b/UnitTests/Test.cs
@@ -22,7 +22,7 @@ namespace UnitTests
             Environment.SetEnvironmentVariable("BABOON_CFG", "testsubject.exe.covcfg" );
             var h = CoverHostFactory.CreateHost ("self.exe.covdb", "covem.exe", "testsubject.exe");
 
-            h.Cover ("assembly:XR.Mono.Cover");
+            h.Cover (null, null, "assembly:XR.Mono.Cover");
 
         }
     }

--- a/XR.Mono.Cover/CoverHost.cs
+++ b/XR.Mono.Cover/CoverHost.cs
@@ -363,6 +363,15 @@ namespace XR.Mono.Cover
             }
         }
 
+        public void Detach ( )
+        {
+            VirtualMachine.Detach();
+        }
+
+        public void Exit ( )
+        {
+            VirtualMachine.Exit(0);
+        }
         
         public void SaveData ( )
         {

--- a/XR.Mono.Cover/CoverHostFactory.cs
+++ b/XR.Mono.Cover/CoverHostFactory.cs
@@ -18,6 +18,29 @@ namespace XR.Mono.Cover
 			var args = new List<string> {program};
 			args.AddRange (arguments);
 
+            var rv = new CoverHost ( args.ToArray() );
+            PrepareHost( rv, covfile );
+			return rv;
+		}
+
+		public static CoverHost CreateHost (string covfile, System.Net.IPEndPoint ip)
+		{
+            if (covfile == null)
+                throw new ArgumentNullException ("covfile");
+
+			if (ip == null)
+				throw new ArgumentNullException ("ip");
+
+            var rv = new CoverHost ( ip );
+            PrepareHost( rv, covfile );
+			return rv;
+        }
+
+        private static void PrepareHost (CoverHost host, string covfile)
+        {
+            if (covfile == null)
+                throw new ArgumentNullException ("covfile");
+
             var data = new CodeRecordData();
             data.Open( covfile );
 
@@ -27,11 +50,8 @@ namespace XR.Mono.Cover
             data.SaveMeta("dbfile", covfile);
             data.SaveMeta("testmachine", Environment.MachineName );
 
-            var rv = new CoverHost ( args.ToArray() ) { 
-                DataStore = data,
-                LogFile = log,
-            };
-			return rv;
-		}
+            host.DataStore = data;
+            host.LogFile = log;
+        }
 	}
 }

--- a/covtool/Program.cs
+++ b/covtool/Program.cs
@@ -58,6 +58,16 @@ can be enabled in the configuration file like this:
 $HitCount=false
 
 
+A static method may be invoked when baboon is ready by telling the
+IL name of the method and the name of a thread like this:
+
+$InvokeMethod=Namespace.TypeName.MethodName
+$InvokeThread=ThreadName
+
+This is particularly useful to delay the execution of the code you are
+interested in before attaching baboon.
+
+
 ");
             Console.WriteLine();
             Console.WriteLine("results are saved in PROGGRAM.covdb");
@@ -111,6 +121,8 @@ $HitCount=false
 		public static int Main (string[] vargs)
 		{
             var index = 0;
+            string invokeMethod = null;
+            string invokeThread = null;
 
             while (index < vargs.Length)
             {
@@ -150,6 +162,14 @@ $HitCount=false
                             bool.TryParse (l, out hitCount);
                             continue;
                         }
+                        if ( l.StartsWith ( "$InvokeMethod=" ) ) {
+                            invokeMethod = l.Substring("$InvokeMethod=".Length);
+                            continue;
+                        }
+                        if ( l.StartsWith ( "$InvokeThread=" ) ) {
+                            invokeThread = l.Substring("$InvokeThread=".Length);
+                            continue;
+                        }
                         patterns.Add (l);
                     } while ( l != null );
                 }
@@ -180,7 +200,7 @@ $HitCount=false
             ThreadPool.QueueUserWorkItem( (x) => SignalHandler(), null );
 
             covertool.HitCount = hitCount;
-            covertool.Cover (patterns.ToArray ());
+            covertool.Cover (invokeMethod, invokeThread, patterns.ToArray ());
             MainClass.covertool = null;
             covertool.Report ( cfgfile + ".covreport" );
 

--- a/covtool/Program.cs
+++ b/covtool/Program.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Net;
 using Mono.Unix;
 using XR.Mono.Cover;
 using System.Collections.Generic;
@@ -15,10 +16,19 @@ namespace Covtool
         public static int Usage()
         {
             Console.WriteLine("Usage: covem PROGRAM ARGUMENTS");
-            Console.WriteLine(@"
-PROGRAM should be the path to your c# exe (not a shell script)
+            Console.WriteLine(@"Usage: covem PROGRAM ARGUMENTS
+       covem -a PROGRAM ADDRESS PORT
 
-Pass covem the same options you would pass to your program.
+Launching PROGRAM on covem:
+ PROGRAM should be the path to your c# exe (not a shell script)
+
+ Pass covem the same options you would pass to your program.
+
+Attaching to an existent process:
+ Pass -a as the first argument.
+ PROGRAM should be a convenient string to identify your program.
+ ADDRESS should be an IP address the process listening to.
+ PORT should be a TCP port the process listening to.
 
 By default coverage will not be recorded. To choose the 
 namespaces covered, create a text file containing a list of types 
@@ -76,11 +86,13 @@ $HitCount=false
         {
             var sig = new UnixSignal( Mono.Unix.Native.Signum.SIGUSR2 );
             var sigs = new UnixSignal[] { sig };
+            var covertool = MainClass.covertool;
 
-            do {
+            while (covertool != null) {
                 UnixSignal.WaitAny( sigs, new TimeSpan(0,1,0) );
                 covertool.SaveData();
-            } while ( debugee != null && !debugee.HasExited );
+                covertool = Volatile.Read(ref MainClass.covertool);
+            }
         }
 
         static Process debugee = null;
@@ -88,15 +100,22 @@ $HitCount=false
 
 		public static int Main (string[] vargs)
 		{
-            if ( vargs.Length == 0 ) return Usage();
-            if ( Regex.IsMatch( vargs[0], "-h$|-help$" ) ) return Usage();
-            if (!System.IO.File.Exists(vargs[0])) return Usage();
+            var attach = false;
+            var index = 0;
+
+            while (index < vargs.Length)
+            {
+                if ( Regex.IsMatch( vargs[index], "-h$|-help$" ) ) return Usage();
+                if ( !Regex.IsMatch( vargs[index], "-a$|-attach$" ) ) break;
+
+                attach = true;
+                index++;
+            }
 
             // the first thing is the mono EXE we are running, everything else are args passed to it
             // we do no argument processing at all.
 
-            var program = vargs[0];
-            var args = vargs.Skip(1);
+            var program = vargs[index];
             var patterns = new List<string> ();
 
             // we look in BABOON_CFG for a config file
@@ -130,16 +149,33 @@ $HitCount=false
             CoverHost.RenameBackupFile( cfgfile + ".covdb" );
             CoverHost.RenameBackupFile( cfgfile + ".covreport" );
 
-            covertool = CoverHostFactory.CreateHost ( cfgfile  + ".covdb", program, args.ToArray() );
+            CoverHost covertool;
+
+            if ( attach ) {
+                if ( !IPAddress.TryParse(vargs[index + 1], out var ip) ) return Usage();
+                if ( !int.TryParse(vargs[index + 2], out var port) ) return Usage();
+
+                covertool = CoverHostFactory.CreateHost ( cfgfile  + ".covdb", new IPEndPoint( ip, port ) );
+            } else {
+                if (!System.IO.File.Exists(program)) return Usage();
+
+                var args = vargs.Skip(index);
+                covertool = CoverHostFactory.CreateHost ( cfgfile  + ".covdb", program, args.ToArray() );
+                debugee = covertool.VirtualMachine.Process;
+                ThreadPool.QueueUserWorkItem( (x) => PumpStdin(x), null );
+            }
+
             covertool.DataStore.SaveMeta( "config", cfgfile );
-            debugee = covertool.VirtualMachine.Process;
+
+            MainClass.covertool = covertool;
             ThreadPool.QueueUserWorkItem( (x) => SignalHandler(), null );
-            ThreadPool.QueueUserWorkItem( (x) => PumpStdin(x), null );
+
             covertool.HitCount = hitCount;
             covertool.Cover (patterns.ToArray ());
+            MainClass.covertool = null;
             covertool.Report ( cfgfile + ".covreport" );
 
-            return covertool.VirtualMachine.Process.ExitCode;
+            return attach ? 0 : covertool.VirtualMachine.Process.ExitCode;
 		}
 	}
 }


### PR DESCRIPTION
The capability of attaching to an existent process is an advantage of Mono Soft Debugger and it is also the reason why it was developed. I would like to use it with Unity (the game engine), but others may find different use cases such as use on Xamarin platforms.

The key change is commit 56dedbe02ad5ce59061d0e57c4f0ef1c7acc3c5d, which just provides `VirtualMachineManager.Connect` as an alternative for `VirtualMachineManager.Launch`. However, in practice (especially when automated), it is not enough and synchronization mechanisms are also necessary to execute the code you are interested in when baboon is ready and to terminate baboon when the code finished. The former is implemented with 523da15584f360a6e66f0e6b2047da42095d9d7f and the later is implemented with d6ffa83041efd4e3f3f5f926158301f9f55f7c42.

Those changes involve interface changes so please be aware of them.