### PR TITLE
Support .NET Framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,11 @@ Use `make installbundle` for installing the bundled version.
 Running
 --------
 
-Be sure to deploy the `libsqlite3.so.0` C library wherever you run your app. If
-it is the same machine as the build was done on you neede't worry. Your 'test'
-program/assembly needs to have been built with debugging enabled (you need the
-mdb files) else baboon won't know how to inspect the running code.
+Be sure to deploy the `libsqlite3.so.0` (or `sqlite3.dll` on Windows) C
+library wherever you run your app. If it is the same machine as the build was
+done on you neede't worry. Your 'test' program/assembly needs to have been
+built with debugging enabled (you need the mdb files) else baboon won't know
+how to inspect the running code.
 
 First, we need to create a coverage config file to tell covem what
 classes/types you want to record coverage data for. If you have a called called

--- a/XR.Mono.Cover/XR.Mono.Cover.csproj
+++ b/XR.Mono.Cover/XR.Mono.Cover.csproj
@@ -9,6 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>XR.Mono.Cover</RootNamespace>
     <AssemblyName>XR.Mono.Cover</AssemblyName>
+    <AssemblySearchPaths>{GAC};$(AssemblySearchPaths)</AssemblySearchPaths>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -34,10 +35,16 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="Mono.Cecil, Version=0.9.5.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756" />
-    <Reference Include="Mono.Data.Sqlite" />
+    <Reference Include="Mono.Cecil, Version=0.9.5.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756">
+      <Private>true</Private>
+    </Reference>
+    <Reference Include="Mono.Data.Sqlite">
+      <Private>true</Private>
+    </Reference>
     <Reference Include="System.Data" />
-    <Reference Include="Mono.Debugger.Soft" />
+    <Reference Include="Mono.Debugger.Soft">
+      <Private>true</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/cov-gtk/cov-gtk.csproj
+++ b/cov-gtk/cov-gtk.csproj
@@ -9,6 +9,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>XR.Baboon</RootNamespace>
     <AssemblyName>cov-gtk</AssemblyName>
+    <AssemblySearchPaths>{GAC};$(AssemblySearchPaths)</AssemblySearchPaths>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
@@ -33,7 +34,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="Mono.Posix" />
+    <Reference Include="Mono.Posix">
+      <Private>true</Private>
+    </Reference>
     <Reference Include="System.Core" />
     <Reference Include="gtk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
       <Package>gtk-sharp-2.0</Package>

--- a/covtool/covtool.csproj
+++ b/covtool/covtool.csproj
@@ -9,6 +9,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>covtool</RootNamespace>
     <AssemblyName>covem</AssemblyName>
+    <AssemblySearchPaths>{GAC};$(AssemblySearchPaths)</AssemblySearchPaths>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
@@ -41,8 +42,12 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="Mono.Posix" />
-    <Reference Include="Mono.Debugger.Soft" />
+    <Reference Include="Mono.Posix">
+      <Private>true</Private>
+    </Reference>
+    <Reference Include="Mono.Debugger.Soft">
+      <Private>true</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />


### PR DESCRIPTION
This change allow .NET Framework to run baboon. (Of course the target is still Mono.)

In details, 9b350b713c5651323c8bcf43eca21117b5df46ae avoids the use of `Mono.Posix` on Windows, and 1236fdca1f6a2a6ef2b22b1c91902f186411af52 copies Mono assemblies to the output.