### PR TITLE
Use msbuild instead of xbuild

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,8 @@
 build:
-  image: ubuntu:16.04
+  image: mono:5.18
   script:
     - |
-      bash cicd/setup_ubuntu.sh
+      apt-get update
+      apt-get install -y libgtk2.0-cil-dev make
       make
       find . -type f -name '*.exe'

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ INSTDIR=/usr/local/lib/baboon
 BINDIR=/usr/local/bin
 
 all:
-	xbuild /property:Configuration=Release 
+	msbuild /property:Configuration=Release 
 
 makebundle: all
 	bash make_bundle.sh

--- a/cicd/setup_ubuntu.sh
+++ b/cicd/setup_ubuntu.sh
@@ -1,2 +1,0 @@
-apt-get update
-apt-get install -y tzdata mono-xbuild libgtk2.0-cil-dev build-essential libmono-debugger-libs-cil-dev


### PR DESCRIPTION
Mono 5.0.0 Release Notes | Mono
https://www.mono-project.com/docs/about-mono/releases/5.0.0/
> Mono’s historical implementation of MSBuild called xbuild is now
> deprecated. We encourage everyone to switch to the msbuild command which
> is now available on Mono as well.