### PR TITLE
Introduce $TerminatorMethod

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,13 @@ significantly.
 `$HitCount=false`
 
 The covering process may be interrupted by sending baboon _SIGINT_. The results
-will still be saved.
+will still be saved. Another way to interrupt the covering process is to specify
+`$TerminatorMethod` in the config file and invoke the method on the covered
+process:
+
+```
+$TerminatorMethod=Namespace.TypeName.MethodName
+```
 
 Attaching to an existent process
 =================================


### PR DESCRIPTION
On Windows, only `ConsoleCtrlHandler` was an option to interrupt baboon. However, generating `ConsoleCtrl` event is difficult because it always requires console, and there is no managed API.

`SIGINT` is a counterpart of POSIX systems, but neither of `ConsoleCtrlHandler` and `ConsoleCtrl` are portable in context of CLR.

`$TerminatorMethod` is an alternative portable and consistent with `$InvokeMethod` / `$InvokeThread`.